### PR TITLE
Make REDIS_HOST an environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN wget "https://github.com/rapidpro/mage/releases/download/v$MAGE_VERSION/mage
     tar -xvf mage-$MAGE_VERSION-bundle.tar.gz && \
     rm mage-$MAGE_VERSION-bundle.tar.gz
 
+ENV REDIS_HOST=localhost
 ENV REDIS_DATABASE=8
 ENV TEMBA_HOST=localhost:8000 TEMBA_AUTH_TOKEN=none
 ENV TWITTER_API_KEY=none TWITTER_API_SECRET=none

--- a/stack/startup.sh
+++ b/stack/startup.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-export REDIS_HOST=$(echo $REDIS_URL | cut -d'/' -f3)
 if [ "x$ENVIRONMENT" = "xproduction" ]; then
 	export PRODUCTION=1
 else


### PR DESCRIPTION
To get this to run I needed to set the REDIS_HOST environment variable explicitly.
The startup script makes reference to a REDIS_URL but doesn't specify how that's 
to be formatted and what it would do with the redis database number if specified 
as the REDIS_DATABASE is a separate environment variable in the Dockerfile.